### PR TITLE
Compress HTML in Liquid

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,3 +7,7 @@ url:            http://perfectionkills.com
 encoding:       UTF-8
 
 exclude:        ["README"]
+
+compress_html:
+  clippings: [html, head, title, base, link, meta, style, body, article, section, nav, aside, h1, h2, h3, h4, h5, h6, hgroup, header, footer, address, p, hr, blockquote, ol, ul, li, dl, dt, dd, figure, figcaption, main, div, table, caption, colgroup, col, tbody, thead, tfoot, tr, td, th]
+  endings: [html, head, body, li, dt, dd, p, rt, rp, optgroup, option, colgroup, caption, thead, tbody, tfoot, tr, td, th]

--- a/_layouts/compress.html
+++ b/_layouts/compress.html
@@ -1,0 +1,11 @@
+---
+#
+# Jekyll layout that compresses HTML
+# v0.3.1
+# https://github.com/penibelst/jekyll-compress-html
+# © 2014 Anatol Broder (http://penibelst.de/)
+# MIT License
+#
+---
+
+{% assign _pres = content | split: '<pre' %}{% for _pre1 in _pres %}{% assign _pre2 = _pre1 | split: '</pre>' %}{% if _pre2.size == 2 %}<pre{{ _pre2.first }}</pre>{% endif %}{% assign _second = _pre2.last | split: ' ' | join: ' ' %}{% for _element in site.compress_html.clippings %}{% assign _edges = ' <element,<element; </element>,</element>;</element> ,</element>' | replace: 'element', _element | split: ';' %}{% for _edge in _edges %}{% assign _replacement = _edge | split: ',' %}{% assign _second = _second | replace: _replacement[0], _replacement[1] %}{% endfor %}{% endfor %}{% for _element in site.compress_html.endings %}{% assign _closing = '</element>' | replace: 'element', _element %}{% assign _second = _second | remove: _closing %}{% endfor %}{{ _second }}{% endfor %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,3 +1,7 @@
+---
+layout: compress
+---
+
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,3 +1,7 @@
+---
+layout: compress
+---
+
 <!DOCTYPE html>
 <html lang="en">
   <head>


### PR DESCRIPTION
There is a way to [compress HTML](https://github.com/penibelst/jekyll-compress-html) on Github Pages. I’m curious what you think about my Liquid based solution.
